### PR TITLE
[APPS-1339] Use the panoply fork of dbstream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dbstream-mongo",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -141,9 +141,8 @@
       }
     },
     "dbstream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dbstream/-/dbstream-1.0.1.tgz",
-      "integrity": "sha1-DGQNlnVYWxSeZl+FLApNo84FQ+0="
+      "version": "git+https://github.com/panoplyio/dbstream.git#7e4fff3cae932186fa48e2ae3bacca6fc99a22fa",
+      "from": "git+https://github.com/panoplyio/dbstream.git#v1.0.3"
     },
     "debug": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dbstream-mongo",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Mongo DB access layer compatible with the Database Stream API",
   "main": "mongo.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/avinoamr/dbstream-mongo.git"
+    "url": "https://github.com/panoplyio/dbstream-mongo.git"
   },
   "keywords": [
     "database",
@@ -21,15 +21,15 @@
   "author": "Roi Avinoam",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/avinoamr/dbstream-mongo/issues"
+    "url": "https://github.com/panoplyio/dbstream-mongo/issues"
   },
-  "homepage": "https://github.com/avinoamr/dbstream-mongo",
+  "homepage": "https://github.com/panoplyio/dbstream-mongo",
   "devDependencies": {
     "mocha": "^6.1.4",
     "sift": "0.0.18"
   },
   "dependencies": {
-    "dbstream": "1.0.1",
+    "dbstream": "git+https://github.com/panoplyio/dbstream#v1.0.3",
     "debug": "4.1.1",
     "extend": "3.0.0",
     "mongodb": "3.1.1"


### PR DESCRIPTION
https://panoply.atlassian.net/browse/APPS-1339

Before this change can be deployed the changes in https://panoply.atlassian.net/browse/APPS-1351 must be deployed, otherwise we risk breaking production (which now simply points to latest master).