### PR TITLE
[PAN-1983] Update mongodb driver to v5 (using mongodb-legacy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x, 20.x]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+
+    - run: npm ci
+
+    - run: npm test

--- a/mongo.js
+++ b/mongo.js
@@ -1,5 +1,5 @@
 const debug = require('debug')('dbstream-mongo');
-const mongodb = require('mongodb');
+const mongodb = require('mongodb-legacy');
 const events = require('events');
 const extend = require('extend');
 const db = require('dbstream');

--- a/mongo.js
+++ b/mongo.js
@@ -62,7 +62,7 @@ Cursor.prototype._remove = function (object, callback) {
     this._conn.open(function (err, collection) {
         if (err) return callback(toError(err));
         var conn = this;
-        collection.remove({ _id: id }, function (err) {
+        collection.deleteOne({ _id: id }, function (err) {
             conn.done();
             callback(toError(err));
         })

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,46 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@mongodb-js/saslprep": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.1.tgz",
+      "integrity": "sha512-t7c5K033joZZMspnHg/gWPE4kandgc2OxE74aYOtGKfgB9VPuVJPix0H6fhmm2erj5PBJ21mqcx34lpIGtUCsQ==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "@types/node": {
+      "version": "20.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+      "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.4"
+      }
+    },
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -41,6 +81,21 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "async-mutex": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
+      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "b4a": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
+      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -52,15 +107,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
-    },
-    "bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -88,9 +134,16 @@
       "dev": true
     },
     "bson": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
+      "dev": true
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true
     },
     "camelcase": {
       "version": "6.3.0",
@@ -161,16 +214,17 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
-    },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "dbstream": {
       "version": "git+https://github.com/panoplyio/dbstream.git#7e4fff3cae932186fa48e2ae3bacca6fc99a22fa",
@@ -189,11 +243,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true
-    },
-    "denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
     },
     "diff": {
       "version": "5.0.0",
@@ -224,6 +273,21 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -231,6 +295,17 @@
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
       }
     },
     "find-up": {
@@ -247,6 +322,12 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
       "dev": true
     },
     "fs.realpath": {
@@ -314,6 +395,16 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "https-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      }
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -327,7 +418,13 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -377,11 +474,6 @@
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-    },
     "js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -408,6 +500,32 @@
       "requires": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
+      }
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
       }
     },
     "memory-pager": {
@@ -491,16 +609,80 @@
       }
     },
     "mongodb": {
-      "version": "3.6.11",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.11.tgz",
-      "integrity": "sha512-4Y4lTFHDHZZdgMaHmojtNAlqkvddX2QQBEN0K//GzxhGwlI9tZ9R0vhbjr1Decw+TF7qK0ZLjQT292XgHRRQgw==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
+      "dev": true,
       "requires": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.0.3",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
+        "@mongodb-js/saslprep": "^1.1.0",
+        "bson": "^5.5.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "mongodb-legacy": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-legacy/-/mongodb-legacy-5.0.0.tgz",
+      "integrity": "sha512-q2G+MRwde6114bCAF/EZLmMXSsebIKMHmzsfOJq6M/Tj4gr3wLT50+rJsJNkiR0e0kjFx3dllWjqwRR1n11Zsw==",
+      "requires": {
+        "mongodb": "^5.0.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+          "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g=="
+        },
+        "mongodb": {
+          "version": "5.9.2",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+          "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
+          "requires": {
+            "@mongodb-js/saslprep": "^1.1.0",
+            "bson": "^5.5.0",
+            "mongodb-connection-string-url": "^2.6.0",
+            "socks": "^2.7.1"
+          }
+        }
+      }
+    },
+    "mongodb-memory-server": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-9.1.3.tgz",
+      "integrity": "sha512-EVVNll0e6QEsNhK7IJI0x51nbmv57E6X8izO3LLEnfbSZNwERG4P5nAjJfglqCSNkT4svKp1/0kzc+ldlQttOg==",
+      "dev": true,
+      "requires": {
+        "mongodb-memory-server-core": "9.1.3",
+        "tslib": "^2.6.2"
+      }
+    },
+    "mongodb-memory-server-core": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-9.1.3.tgz",
+      "integrity": "sha512-94pUuTgjb6NglCbKLEZm457aACxeaT8+Jw8weEy0DyWiCBd1mk8dIuq7GE1CjmHFU2hMOCnOutdR96LhkWpgig==",
+      "dev": true,
+      "requires": {
+        "async-mutex": "^0.4.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.3.4",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.15.3",
+        "https-proxy-agent": "^7.0.2",
+        "mongodb": "^5.9.1",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.5.4",
+        "tar-stream": "^3.0.0",
+        "tslib": "^2.6.2",
+        "yauzl": "^2.10.0"
       }
     },
     "ms": {
@@ -513,6 +695,15 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
       "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true
+    },
+    "new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.4"
+      }
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -527,14 +718,6 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "optional-require": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
-      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
-      "requires": {
-        "require-at": "^1.0.6"
       }
     },
     "p-limit": {
@@ -555,6 +738,12 @@
         "p-limit": "^3.0.2"
       }
     },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -567,16 +756,76 @@
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        }
+      }
+    },
+    "punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+    },
+    "queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "dev": true
     },
     "randombytes": {
       "version": "2.1.0",
@@ -585,27 +834,6 @@
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
       }
     },
     "readdirp": {
@@ -617,11 +845,6 @@
         "picomatch": "^2.2.1"
       }
     },
-    "require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -631,15 +854,16 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
-    "saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "optional": true,
+    "semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
       "requires": {
-        "sparse-bitfield": "^3.0.3"
+        "lru-cache": "^6.0.0"
       }
     },
     "serialize-javascript": {
@@ -651,11 +875,19 @@
         "randombytes": "^2.1.0"
       }
     },
-    "sift": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-0.0.18.tgz",
-      "integrity": "sha1-HV85c14ktGVD2AbSdMgZf9ksVKQ=",
-      "dev": true
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
+    "socks": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "requires": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      }
     },
     "sparse-bitfield": {
       "version": "3.0.3",
@@ -664,6 +896,16 @@
       "optional": true,
       "requires": {
         "memory-pager": "^1.0.2"
+      }
+    },
+    "streamx": {
+      "version": "2.15.6",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.6.tgz",
+      "integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
+      "dev": true,
+      "requires": {
+        "fast-fifo": "^1.1.0",
+        "queue-tick": "^1.0.1"
       }
     },
     "string-width": {
@@ -675,21 +917,6 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
       }
     },
     "strip-ansi": {
@@ -716,6 +943,17 @@
         "has-flag": "^4.0.0"
       }
     },
+    "tar-stream": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
+      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+      "dev": true,
+      "requires": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -725,10 +963,38 @@
         "is-number": "^7.0.0"
       }
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    "tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "requires": {
+        "punycode": "^2.1.1"
+      }
+    },
+    "tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+    },
+    "whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "requires": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      }
     },
     "workerpool": {
       "version": "6.2.1",
@@ -757,6 +1023,12 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yargs": {
@@ -790,6 +1062,16 @@
         "decamelize": "^4.0.0",
         "flat": "^5.0.2",
         "is-plain-obj": "^2.1.0"
+      }
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Mongo DB access layer compatible with the Database Stream API",
   "main": "mongo.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha --exit"
   },
   "repository": {
     "type": "git",
@@ -26,12 +26,12 @@
   "homepage": "https://github.com/panoplyio/dbstream-mongo",
   "devDependencies": {
     "mocha": "^10.2.0",
-    "sift": "0.0.18"
+    "mongodb-memory-server": "^9.1.3"
   },
   "dependencies": {
     "dbstream": "git+https://github.com/panoplyio/dbstream#v1.0.3",
     "debug": "^4.3.4",
     "extend": "^3.0.2",
-    "mongodb": "3.6.11"
+    "mongodb-legacy": "^5.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,32 +1,42 @@
-const test = require("dbstream/test");
-const mongodb = require("mongodb");
-const stream = require("stream");
-const events = require("events");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const mongodb = require("mongodb-legacy");
 const assert = require("assert");
-const sift = require("sift");
+const test = require("dbstream/test");
 const db = require("./mongo");
 
-const connect = mongodb.MongoClient.connect;
-
-const options = { collection: "test", _closeTimeOut: 1 };
-const addr = "mongodb://127.0.0.1:27017/test1";
 
 describe("DatabaseStream Mongo", function () {
 
-    beforeEach(function () {
-        mongodb.MongoClient.connect = mock_connect;
-    })
+    let mongod, mongoUri;
+    const connect = mongodb.MongoClient.connect;
 
-    after(function () {
+    before(async function () {
         mongodb.MongoClient.connect = connect;
+
+        mongod = await MongoMemoryServer.create();
+        mongoUri = mongod.getUri();
     })
 
-    it("Implements the dbstream API", test(db.connect(addr, options)));
+    after(async function () {
+        mongodb.MongoClient.connect = connect;
+
+        await mongod.stop();
+    })
+
+    it("Implements the dbstream API", function (done) {
+        const addr = mongoUri + "test1";
+        const options = { collection: "test1" }
+        const conn = db.connect(addr, options)
+
+        const t = test(conn);
+
+        t(done);
+    });
 
     it("Supports multiple collections", function (done) {
-        const addr = "mongodb://127.0.0.1:27017/test2";
-        const options1 = { collection: "test2", _closeTimeOut: 1 }
-        const options2 = { collection: "test3", _closeTimeOut: 1 }
+        const addr = mongoUri + "test2";
+        const options1 = { collection: "test2" }
+        const options2 = { collection: "test3" }
         const conn1 = db.connect(addr, options1)
         const conn2 = db.connect(addr, options2)
 
@@ -51,7 +61,7 @@ describe("DatabaseStream Mongo", function () {
             callback({ err: "Something went wrong" });
         }
 
-        const addr = "mongodb://127.0.0.1:27017/test4";
+        const addr = mongoUri + "test4";
         const conn = db.connect(addr, { collection: "test4" })
 
         new conn.Cursor()
@@ -69,7 +79,7 @@ describe("DatabaseStream Mongo", function () {
             return callback({ err: "connection to [127.0.0.1:27017] timed out" });
         }
 
-        const addr = "mongodb://127.0.0.1:27017/test5";
+        const addr = mongoUri + "test5";
         const conn = db.connect(addr, { collection: "test5", maxRetries: 3 })
 
         conn.on("error", function () {
@@ -83,117 +93,4 @@ describe("DatabaseStream Mongo", function () {
             .find({})
     })
 
-    // ensure that all the connections were closed
-    after(function (done) {
-        this.timeout(15 * 1000);
-        setTimeout(function () {
-            var dbkeys = Object.keys(dbs);
-            assert.equal(dbkeys.length, 0, "No all connections were closed: " + dbkeys)
-            done();
-        }, 11 * 1000);
-    })
-
 });
-
-const dbs = {};
-
-function mock_connect(url, options, callback) {
-    dbs[url] || (dbs[url] = {});
-    process.nextTick(function () {
-        const client = new events.EventEmitter();
-        const db = {}
-
-        db.collection = function (name) {
-            if (!dbs[url][name]) {
-                dbs[url][name] = mock_collection();
-            }
-            return dbs[url][name];
-        };
-
-        client.db = function () {
-            return db
-        };
-
-        client.close = function (callback) {
-            process.nextTick(function () {
-                delete dbs[url];
-                this.collection = function () {
-                    throw new Error("Client connection has been closed");
-                }
-            }.bind(this));
-        };
-
-        callback(null, client);
-    })
-}
-
-function mock_collection() {
-    let data = [];
-    return {
-        insertOne: function (obj, callback) {
-            obj = copy(obj);
-            if (!obj._id) {
-                obj._id = (Math.random() * 1e17).toString(36);
-            }
-            this.remove({ _id: obj._id }, function (err, is_update) {
-                data.push(obj);
-                process.nextTick(function () {
-                    callback(null, (is_update) ? 1 : copy(obj));
-                })
-            });
-        },
-        replaceOne: function (filter, obj, options, callback) {
-            this.insertOne(obj, callback)
-        },
-        remove: function (query, callback) {
-            const sifter = sift(query);
-            let removed = 0;
-
-            data = data.filter(function (obj) {
-                if (!sifter.test(obj)) {
-                    return true;
-                } else {
-                    removed += 1;
-                    return false;
-                }
-            });
-            process.nextTick(function () {
-                callback(null, removed);
-            });
-        },
-        find: function (query, options) {
-            const sort = options.sort || [];
-            const skip = options.skip || 0;
-            const limit = options.limit || Infinity;
-            const s = new stream.Readable({ objectMode: true });
-            const results = sift(query, data);
-
-            results.sort(function (d1, d2) {
-                for (var s = 0; s < sort.length; s += 1) {
-                    s = sort[s];
-                    if (d1[s[0]] == d2[s[0]]) continue;
-                    return d1[s[0]] > d2[s[0]]
-                        ? s[1] : -s[1];
-                }
-                return 0;
-            })
-            results.splice(0, skip)
-            results.splice(limit);
-
-            s._read = function () {
-                if (results.length == 0) return this.push(null);
-                this.push(copy(results.shift()));
-            }
-
-            return {
-                stream: function () {
-                    return s;
-                }
-            }
-        },
-    }
-}
-
-function copy(obj) {
-    return JSON.parse(JSON.stringify(obj));
-}

--- a/test.js
+++ b/test.js
@@ -23,37 +23,34 @@ describe("DatabaseStream Mongo", function () {
         await mongod.stop();
     })
 
+    beforeEach(async function () {
+        mongodb.MongoClient.connect = connect;
+    })
+
     it("Implements the dbstream API", function (done) {
         const addr = mongoUri + "test1";
-        const options = { collection: "test1" }
-        const conn = db.connect(addr, options)
+        const options = { collection: "test1" };
+        const conn = db.connect(addr, options);
 
         const t = test(conn);
 
         t(done);
     });
 
-    it("Supports multiple collections", function (done) {
+    it("Supports multiple collections", async function () {
         const addr = mongoUri + "test2";
-        const options1 = { collection: "test2" }
-        const options2 = { collection: "test3" }
-        const conn1 = db.connect(addr, options1)
-        const conn2 = db.connect(addr, options2)
 
-        const data = [];
-        new conn1.Cursor()
-            .on("error", done)
-            .on("finish", function () {
-                new conn2.Cursor()
-                    .on("error", done)
-                    .on("data", data.push.bind(data))
-                    .on("end", function () {
-                        assert.deepEqual(data, []);
-                        done();
-                    })
-                    .find({})
-            })
-            .end({ hello: "world" })
+        const conn1 = new Connection(addr, { collection: "test2" });
+        const conn2 = new Connection(addr, { collection: "test3" });
+
+        await conn2.save({ hello: "world" });
+
+        const res1 = await conn1.find({});
+        const res2 = await conn2.find({});
+
+        assert.equal(res1.length, 0);
+        assert.equal(res2.length, 1);
+        assert.equal(res2[0].hello, "world");
     })
 
     it("Throws connection errors", function (done) {
@@ -62,29 +59,30 @@ describe("DatabaseStream Mongo", function () {
         }
 
         const addr = mongoUri + "test4";
-        const conn = db.connect(addr, { collection: "test4" })
+        const conn = db.connect(addr, { collection: "test4" });
 
         new conn.Cursor()
             .on("error", function (err) {
-                assert(err.message, "Something went wrong")
+                assert(err instanceof Error);
+                assert(err.message, "Something went wrong");
                 done();
             })
             .end({ hello: "world" })
     })
 
     it("Retries connecting on timeout", function (done) {
-        let called = 0
+        let called = 0;
         mongodb.MongoClient.connect = function (url, options, callback) {
-            called += 1
+            called += 1;
             return callback({ err: "connection to [127.0.0.1:27017] timed out" });
         }
 
         const addr = mongoUri + "test5";
-        const conn = db.connect(addr, { collection: "test5", maxRetries: 3 })
+        const conn = db.connect(addr, { collection: "test5", maxRetries: 3 });
 
         conn.on("error", function () {
-            assert.equal(called, 3)
-            done()
+            assert.equal(called, 3);
+            done();
         })
 
         new conn.Cursor()
@@ -93,4 +91,135 @@ describe("DatabaseStream Mongo", function () {
             .find({})
     })
 
+    it("Creates a document", async function () {
+        const addr = mongoUri + "test6";
+        const conn = new Connection(addr);
+
+        const value = 1;
+
+        // no doc should exist before the insert
+        const res1 = await conn.find({ value });
+        assert.deepEqual(res1.length, 0);
+
+        // now add the doc and verify we can find it
+        await conn.save({ value });
+        const res2 = await conn.find({ value });
+        const doc = res2[0];
+
+        assert.deepEqual(res2.length, 1);
+        assert.deepEqual(doc.value, value);
+        assert(doc.id);
+    })
+
+    it("Updates a document", async function () {
+        const addr = mongoUri + "test7";
+        const conn = new Connection(addr);
+
+        const value1 = 1;
+        const value2 = 2;
+
+        // create the doc
+        await conn.save({ value: value1 });
+        const res1 = await conn.find({ value: value1 });
+        const doc1 = res1[0];
+
+        assert.deepEqual(res1.length, 1);
+        assert.deepEqual(doc1.value, value1);
+
+        // update the doc
+        await conn.save({ value: value2, id: doc1.id });
+        const res2 = await conn.find({ value: value2 });
+        const doc2 = res2[0];
+
+        assert.deepEqual(res2.length, 1);
+        assert.deepEqual(doc2.value, value2);
+
+        // verify we worked on the same doc
+        assert.deepEqual(doc1.id, doc2.id);
+    })
+
+    it("Deletes a document", async function () {
+        const addr = mongoUri + "test8";
+        const conn = new Connection(addr);
+
+        const value = 1;
+
+        // add the doc and verify we can find it
+        await conn.save({ value });
+        const res1 = await conn.find({ value });
+        assert.deepEqual(res1.length, 1);
+
+        // now delete the doc and verify we can't find it
+        await conn.drop({ id: res1[0].id });
+        const res2 = await conn.find({ id: res1[0].id });
+        assert.deepEqual(res2.length, 0);
+    })
+
+    it("Finds many documents", async function () {
+        const addr = mongoUri + "test9";
+        const conn = new Connection(addr);
+
+        const value = 'a';
+
+        // make sure we start with a clean plate
+        const res1 = await conn.find({});
+        assert.deepEqual(res1.length, 0);
+
+        // now add the doc and verify we can find it
+        await conn.save({ value });
+        await conn.save({ value });
+        await conn.save({ value: 'b' });
+        const res2 = await conn.find({ value });
+
+        assert.equal(res2.length, 2);
+        assert.equal(res2[0].value, value);
+        assert.equal(res2[1].value, value);
+        assert.notEqual(res2[0].id, res2[1].id);
+    })
 });
+
+/**
+ * This promise based API aims to reduce the boilerplate of properly handling
+ * different stream events and function calls.
+ *
+ * An API like this can be useful in the package itself but making it production
+ * ready will require more thought and effort than there's time and need to right now.
+ */
+class Connection {
+    constructor(addr, options = { collection: 'test' }) {
+        this._conn = db.connect(addr, options)
+    }
+
+    async find(query) {
+        const results = []
+
+        return new Promise((resolve, reject) => {
+            new this._conn.Cursor()
+                .on("error", reject)
+                .on("end", () => resolve(results))
+                .on("data", results.push.bind(results))
+                .find(query)
+        })
+    }
+
+    async save(object) {
+        return new Promise((resolve, reject) => {
+            new this._conn.Cursor()
+                .on("error", reject)
+                .on("finish", resolve)
+                .end(object)
+        })
+    }
+
+    async drop(object) {
+        return new Promise((resolve, reject) => {
+            const cursor = new this._conn.Cursor()
+
+            cursor.on("error", reject)
+                .on("finish", resolve)
+                .remove(object)
+
+            cursor.end()
+        })
+    }
+}


### PR DESCRIPTION
https://panoply.atlassian.net/browse/PAN-1983

~The implementation did not change only the driver dependency was. Downstream clients should be able to use this package without modifying anything because the v5 driver supports the previously used v3.6 features ([see official docs](https://www.mongodb.com/docs/drivers/node/current/compatibility/#compatibility-table-legend)).~

- We use `mongodb-legacy` to keep using the callback api
- We use `mongodb-memory-server` to test against the actual driver instead of a mock implementation

After further tests I saw that:
- `collection.remove()` is no longer supported
  - I replaced it with `collection.deleteOne()`
  - I added tests for basic CRUD operations
- `collection.update()` is no longer supported
  - The method is not used in this package but the [panoply repo uses the underlying mongo driver directly](https://github.com/panoplyio/panoply/blob/3f5de5a4be1a4c2557abbab1d7f07837a6115aad/src/db/sync.js#L212) with the `update()` method so that will have to be updated as well