### PR TITLE
[PAN-1983] Fix wrong results returned from the save method

### DIFF
--- a/mongo.js
+++ b/mongo.js
@@ -37,15 +37,13 @@ Cursor.prototype._save = function (object, callback) {
 
         function ondone(err, result) {
             conn.done();
+
             if (err) return callback(toError(err));
-            if (typeof result == 'object') {
-                if (result.ops && result.ops.length > 0) {
-                    result = result.ops[0];
-                }
-                result.id = fromObjectID(result._id);
-                delete result._id;
-                replace(object, result);
+
+            if (result.insertedId) {
+                object.id = fromObjectID(result.insertedId);
             }
+
             callback();
         }
 
@@ -61,6 +59,7 @@ Cursor.prototype._remove = function (object, callback) {
     var id = toObjectID(object.id);
     this._conn.open(function (err, collection) {
         if (err) return callback(toError(err));
+
         var conn = this;
         collection.deleteOne({ _id: id }, function (err) {
             conn.done();
@@ -89,6 +88,7 @@ Cursor.prototype._load = function () {
     var that = this;
     this._conn.open(function (err, collection) {
         if (err) return this.emit('error', toError(err));
+
         var conn = this;
         collection
             .find(query, options)

--- a/test.js
+++ b/test.js
@@ -102,13 +102,19 @@ describe("DatabaseStream Mongo", function () {
         assert.deepEqual(res1.length, 0);
 
         // now add the doc and verify we can find it
-        await conn.save({ value });
+        const obj = { value }
+        await conn.save(obj);
+
+        // the passed object must be modified in place to not break the api
+        // this is why we expect to find the mongo generated id on it
+        assert(obj.id);
+
         const res2 = await conn.find({ value });
         const doc = res2[0];
 
         assert.deepEqual(res2.length, 1);
         assert.deepEqual(doc.value, value);
-        assert(doc.id);
+        assert(doc.id, obj.id);
     })
 
     it("Updates a document", async function () {
@@ -161,11 +167,11 @@ describe("DatabaseStream Mongo", function () {
 
         const value = 'a';
 
-        // make sure we start with a clean plate
+        // make sure we start with a clean slate
         const res1 = await conn.find({});
         assert.deepEqual(res1.length, 0);
 
-        // now add the doc and verify we can find it
+        // now add some docs and verify we find a subset of them
         await conn.save({ value });
         await conn.save({ value });
         await conn.save({ value: 'b' });


### PR DESCRIPTION
https://panoply.atlassian.net/browse/PAN-1983

The updated mongodb driver no longer supports returning the `ops` array which contained the entire document(s) inserted, now it only returns the `_id` field. This breaking change caused objects passed to the save method to have `id: undefined` set on them and that messed up consumer code (the panoply codebase).

To keep the behavior as close to the old one I'm assigning the returned id to the same object that was passed to the `save()` method.

References:
- The old driver [insert result docs](https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#~insertOneWriteOpResult)
- The new driver [insert result docs](https://mongodb.github.io/node-mongodb-native/5.9/interfaces/InsertOneResult.html)