### PR TITLE
Bump major version (v3.0.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dbstream-mongo",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dbstream-mongo",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Mongo DB access layer compatible with the Database Stream API",
   "main": "mongo.js",
   "scripts": {


### PR DESCRIPTION
The new mongodb driver has breaking changes and because clients are able to use the raw mongodb connection those breaking changes will leak over.